### PR TITLE
[bugfix] fix runtime bug: 'int' object has no attribute 'split'

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -48,7 +48,7 @@ class BlumTod:
             },
         )
         headers["Content-Length"] = str(len(data))
-        url = "https://gateway.blum.codes/v1/auth/provider/PROVIDER_TELEGRAM_MINI_APP"
+        url = "https://user-domain.blum.codes/api/v1/auth/provider/PROVIDER_TELEGRAM_MINI_APP"
         res = self.http(url, headers, data)
         token = res.json().get("token")
         if token is None:
@@ -410,9 +410,9 @@ class BlumTod:
                 access_token = self.get_local_token(userid)
                 failed_fetch_token = False
                 while True:
-                    if access_token is False:
+                    if not access_token:
                         access_token = self.renew_access_token(data)
-                        if access_token is False:
+                        if not access_token:
                             self.save_failed_token(userid, data)
                             failed_fetch_token = True
                             break


### PR DESCRIPTION
reason: blum have changed the get token url, resulting the token in tokens.json file be 0, not a valid token.

#21